### PR TITLE
fix: remove whitespace during comparison to bypass scraping mismatches

### DIFF
--- a/src/ahlbatross/main.py
+++ b/src/ahlbatross/main.py
@@ -3,6 +3,7 @@ AHB data fetching and parsing as well as csv imports, processing and exports.
 """
 
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Any, Tuple, TypeAlias
@@ -183,6 +184,15 @@ def create_row(
     return row
 
 
+def normalize(value: str | None) -> str:
+    """
+    normalizes strings like `Segmentname` values by removing all whitespaces, tabs, newlines, etc.
+    """
+    if value is None:
+        return ""
+    return re.sub(r"\s+", "", value)
+
+
 # pylint:disable=too-many-branches, too-many-statements
 def align_columns(
     previous_pruefid: DataFrame,
@@ -285,11 +295,11 @@ def align_columns(
 
     # normalize `Segmentname` columns values by removing any whitespace
     segments_of_previous_formatversion_normalized = [
-        s.replace(" ", "") if isinstance(s, str) else s
+        normalize(s) if isinstance(s, str) else s
         for s in df_of_previous_formatversion[f"Segmentname_{previous_formatversion}"].tolist()
     ]
     segments_of_subsequent_formatversion_normalized = [
-        s.replace(" ", "") if isinstance(s, str) else s
+        normalize(s) if isinstance(s, str) else s
         for s in df_of_subsequent_formatversion[f"Segmentname_{subsequent_formatversion}"].tolist()
     ]
 

--- a/src/ahlbatross/main.py
+++ b/src/ahlbatross/main.py
@@ -192,6 +192,7 @@ def align_columns(
 ) -> DataFrame:
     """
     aligns `Segmentname` columns by adding empty cells each time the cell values do not match.
+    during comparison, whitespaces are removed while preserving original values for the output.
     """
 
     default_column_order = [
@@ -282,6 +283,17 @@ def align_columns(
         result_df = pd.DataFrame(result_rows)
         return result_df[column_order]
 
+    # normalize `Segmentname` columns values by removing any whitespace
+    segments_of_previous_formatversion_normalized = [
+        s.replace(" ", "") if isinstance(s, str) else s
+        for s in df_of_previous_formatversion[f"Segmentname_{previous_formatversion}"].tolist()
+    ]
+    segments_of_subsequent_formatversion_normalized = [
+        s.replace(" ", "") if isinstance(s, str) else s
+        for s in df_of_subsequent_formatversion[f"Segmentname_{subsequent_formatversion}"].tolist()
+    ]
+
+    # keep original `Segmentname` values for output
     segments_of_previous_formatversion = df_of_previous_formatversion[f"Segmentname_{previous_formatversion}"].tolist()
     segments_of_subsequent_formatversion = df_of_subsequent_formatversion[
         f"Segmentname_{subsequent_formatversion}"
@@ -317,7 +329,7 @@ def align_columns(
             row["changed_entries"] = ""
             result_rows.append(row)
             i += 1
-        elif segments_of_previous_formatversion[i] == segments_of_subsequent_formatversion[j]:
+        elif segments_of_previous_formatversion_normalized[i] == segments_of_subsequent_formatversion_normalized[j]:
             row = create_row(
                 previous_df=df_of_previous_formatversion,
                 subsequent_df=df_of_subsequent_formatversion,
@@ -341,8 +353,8 @@ def align_columns(
                 prev_val = str(df_of_previous_formatversion.iloc[i][col])
                 subs_val = str(df_of_subsequent_formatversion.iloc[j][col])
 
-                # only consider cells/entries that are not empty for both formatversions.
-                if prev_val.strip() and subs_val.strip() and prev_val != subs_val:
+                # consider a change when (1) at least one value is non-empty AND (2) the values are different
+                if (prev_val.strip() or subs_val.strip()) and prev_val != subs_val:
                     has_changes = True
                     changed_entries.extend([f"{col}_{previous_formatversion}", f"{col}_{subsequent_formatversion}"])
 
@@ -354,19 +366,27 @@ def align_columns(
         else:
             try:
                 # try to find next matching value.
-                next_match = segments_of_subsequent_formatversion[j:].index(segments_of_previous_formatversion[i])
-                for k in range(next_match):
-                    row = create_row(
-                        previous_df=df_of_previous_formatversion,
-                        subsequent_df=df_of_subsequent_formatversion,
-                        j=j + k,
-                        previous_formatversion=previous_formatversion,
-                        subsequent_formatversion=subsequent_formatversion,
-                    )
-                    row["Änderung"] = "NEU"
-                    row["changed_entries"] = ""
-                    result_rows.append(row)
-                j += next_match
+                next_match = -1
+                for k, subsequent_value in enumerate(segments_of_subsequent_formatversion_normalized[j:], start=j):
+                    if subsequent_value == segments_of_previous_formatversion_normalized[i]:
+                        next_match = k - j
+                        break
+
+                if next_match >= 0:
+                    for k in range(next_match):
+                        row = create_row(
+                            previous_df=df_of_previous_formatversion,
+                            subsequent_df=df_of_subsequent_formatversion,
+                            j=j + k,
+                            previous_formatversion=previous_formatversion,
+                            subsequent_formatversion=subsequent_formatversion,
+                        )
+                        row["Änderung"] = "NEU"
+                        row["changed_entries"] = ""
+                        result_rows.append(row)
+                    j += next_match
+                else:
+                    raise ValueError("no match found.")
             except ValueError:
                 # no match found: add old value and empty new cell.
                 row = create_row(

--- a/unittests/test_process_csv.py
+++ b/unittests/test_process_csv.py
@@ -18,6 +18,40 @@ class TestSingleColumnDataframes:
     def setup(self, formatversions: FormatVersions) -> None:
         self.formatversions = formatversions
 
+    def test_remove_whitespace_during_comparison(self) -> None:
+        """
+        this test case should not detect any since whitespace is removed during the comparison process
+        """
+        previous_pruefid = pd.DataFrame({"Segmentname": ["Seg ment", "Seg ment", "Segment", "Segment"]})
+        subsequent_pruefid = pd.DataFrame({"Segmentname": ["Segment", "Segment", "Seg ment", "Seg ment"]})
+
+        expected_output: DataFrame = pd.DataFrame(
+            {
+                f"Segmentname_{self.formatversions.previous_formatversion}": [
+                    "Seg ment",
+                    "Seg ment",
+                    "Segment",
+                    "Segment",
+                ],
+                "Änderung": ["", "", "", ""],
+                "changed_entries": ["", "", "", ""],
+                f"Segmentname_{self.formatversions.subsequent_formatversion}": [
+                    "Segment",
+                    "Segment",
+                    "Seg ment",
+                    "Seg ment",
+                ],
+            }
+        )
+
+        output_df = align_columns(
+            previous_pruefid,
+            subsequent_pruefid,
+            previous_formatversion=self.formatversions.previous_formatversion,
+            subsequent_formatversion=self.formatversions.subsequent_formatversion,
+        )
+        assert_frame_equal(output_df, expected_output)
+
     def test_align_columns(self) -> None:
         previous_pruefid = pd.DataFrame({"Segmentname": ["1", "2", "3", "4", "5", "6", "9", "10"]})
         subsequent_pruefid = pd.DataFrame({"Segmentname": ["1", "2", "3", "5", "6", "7", "8", "9", "10"]})
@@ -177,6 +211,67 @@ class TestMultiColumnDataFrames:
     @pytest.fixture(autouse=True)
     def setup(self, formatversions: FormatVersions) -> None:
         self.formatversions = formatversions
+
+    def test_remove_whitespace_during_comparison(self) -> None:
+        """
+        this test case should not detect any since whitespace is removed during the comparison process
+        """
+        previous_pruefid = pd.DataFrame(
+            {
+                "Segmentname": ["Seg ment", "Seg ment", "Segment", "Segment"],
+                "Segmentgruppe": ["a", "b", "c", ""],
+            }
+        )
+        subsequent_pruefid = pd.DataFrame(
+            {
+                "Segmentname": ["Segment", "Segment", "Seg ment", "Seg ment"],
+                "Segmentgruppe": ["a", "b", "d", "d"],
+            }
+        )
+
+        expected_output: DataFrame = pd.DataFrame(
+            {
+                f"Segmentname_{self.formatversions.previous_formatversion}": [
+                    "Seg ment",
+                    "Seg ment",
+                    "Segment",
+                    "Segment",
+                ],
+                f"Segmentgruppe_{self.formatversions.previous_formatversion}": [
+                    "a",
+                    "b",
+                    "c",
+                    "",
+                ],
+                "Änderung": ["", "", "ÄNDERUNG", "ÄNDERUNG"],
+                "changed_entries": [
+                    "",
+                    "",
+                    "Segmentgruppe_FV2410|Segmentgruppe_FV2504",
+                    "Segmentgruppe_FV2410|Segmentgruppe_FV2504",
+                ],
+                f"Segmentname_{self.formatversions.subsequent_formatversion}": [
+                    "Segment",
+                    "Segment",
+                    "Seg ment",
+                    "Seg ment",
+                ],
+                f"Segmentgruppe_{self.formatversions.subsequent_formatversion}": [
+                    "a",
+                    "b",
+                    "d",
+                    "d",
+                ],
+            }
+        )
+
+        output_df = align_columns(
+            previous_pruefid,
+            subsequent_pruefid,
+            previous_formatversion=self.formatversions.previous_formatversion,
+            subsequent_formatversion=self.formatversions.subsequent_formatversion,
+        )
+        assert_frame_equal(output_df, expected_output)
 
     def test_align_columns(self) -> None:
         previous_pruefid = pd.DataFrame(

--- a/unittests/test_process_csv.py
+++ b/unittests/test_process_csv.py
@@ -18,7 +18,7 @@ class TestSingleColumnDataframes:
     def setup(self, formatversions: FormatVersions) -> None:
         self.formatversions = formatversions
 
-    def test_remove_whitespace_during_comparison(self) -> None:
+    def test_remove_whitespace_space(self) -> None:
         """
         this test case should not detect any since whitespace is removed during the comparison process
         """
@@ -40,6 +40,74 @@ class TestSingleColumnDataframes:
                     "Segment",
                     "Seg ment",
                     "Seg ment",
+                ],
+            }
+        )
+
+        output_df = align_columns(
+            previous_pruefid,
+            subsequent_pruefid,
+            previous_formatversion=self.formatversions.previous_formatversion,
+            subsequent_formatversion=self.formatversions.subsequent_formatversion,
+        )
+        assert_frame_equal(output_df, expected_output)
+
+    def test_remove_whitespace_newline(self) -> None:
+        """
+        this test case should not detect any since whitespace is removed during the comparison process
+        """
+        previous_pruefid = pd.DataFrame({"Segmentname": ["Seg\nment", "Seg\nment", "Segment", "Segment"]})
+        subsequent_pruefid = pd.DataFrame({"Segmentname": ["Segment", "Segment", "Seg\nment", "Seg\nment"]})
+
+        expected_output: DataFrame = pd.DataFrame(
+            {
+                f"Segmentname_{self.formatversions.previous_formatversion}": [
+                    "Seg\nment",
+                    "Seg\nment",
+                    "Segment",
+                    "Segment",
+                ],
+                "Änderung": ["", "", "", ""],
+                "changed_entries": ["", "", "", ""],
+                f"Segmentname_{self.formatversions.subsequent_formatversion}": [
+                    "Segment",
+                    "Segment",
+                    "Seg\nment",
+                    "Seg\nment",
+                ],
+            }
+        )
+
+        output_df = align_columns(
+            previous_pruefid,
+            subsequent_pruefid,
+            previous_formatversion=self.formatversions.previous_formatversion,
+            subsequent_formatversion=self.formatversions.subsequent_formatversion,
+        )
+        assert_frame_equal(output_df, expected_output)
+
+    def test_remove_whitespace_tab(self) -> None:
+        """
+        this test case should not detect any since whitespace is removed during the comparison process
+        """
+        previous_pruefid = pd.DataFrame({"Segmentname": ["Seg\tment", "Seg\tment", "Segment", "Segment"]})
+        subsequent_pruefid = pd.DataFrame({"Segmentname": ["Segment", "Segment", "Seg\tment", "Seg\tment"]})
+
+        expected_output: DataFrame = pd.DataFrame(
+            {
+                f"Segmentname_{self.formatversions.previous_formatversion}": [
+                    "Seg\tment",
+                    "Seg\tment",
+                    "Segment",
+                    "Segment",
+                ],
+                "Änderung": ["", "", "", ""],
+                "changed_entries": ["", "", "", ""],
+                f"Segmentname_{self.formatversions.subsequent_formatversion}": [
+                    "Segment",
+                    "Segment",
+                    "Seg\tment",
+                    "Seg\tment",
                 ],
             }
         )
@@ -212,7 +280,7 @@ class TestMultiColumnDataFrames:
     def setup(self, formatversions: FormatVersions) -> None:
         self.formatversions = formatversions
 
-    def test_remove_whitespace_during_comparison(self) -> None:
+    def test_remove_whitespace_space(self) -> None:
         """
         this test case should not detect any since whitespace is removed during the comparison process
         """
@@ -255,6 +323,128 @@ class TestMultiColumnDataFrames:
                     "Segment",
                     "Seg ment",
                     "Seg ment",
+                ],
+                f"Segmentgruppe_{self.formatversions.subsequent_formatversion}": [
+                    "a",
+                    "b",
+                    "d",
+                    "d",
+                ],
+            }
+        )
+
+        output_df = align_columns(
+            previous_pruefid,
+            subsequent_pruefid,
+            previous_formatversion=self.formatversions.previous_formatversion,
+            subsequent_formatversion=self.formatversions.subsequent_formatversion,
+        )
+        assert_frame_equal(output_df, expected_output)
+
+    def test_remove_whitespace_newline(self) -> None:
+        """
+        this test case should not detect any since whitespace is removed during the comparison process
+        """
+        previous_pruefid = pd.DataFrame(
+            {
+                "Segmentname": ["Seg\nment", "Seg\nment", "Segment", "Segment"],
+                "Segmentgruppe": ["a", "b", "c", ""],
+            }
+        )
+        subsequent_pruefid = pd.DataFrame(
+            {
+                "Segmentname": ["Segment", "Segment", "Seg\nment", "Seg\nment"],
+                "Segmentgruppe": ["a", "b", "d", "d"],
+            }
+        )
+
+        expected_output: DataFrame = pd.DataFrame(
+            {
+                f"Segmentname_{self.formatversions.previous_formatversion}": [
+                    "Seg\nment",
+                    "Seg\nment",
+                    "Segment",
+                    "Segment",
+                ],
+                f"Segmentgruppe_{self.formatversions.previous_formatversion}": [
+                    "a",
+                    "b",
+                    "c",
+                    "",
+                ],
+                "Änderung": ["", "", "ÄNDERUNG", "ÄNDERUNG"],
+                "changed_entries": [
+                    "",
+                    "",
+                    "Segmentgruppe_FV2410|Segmentgruppe_FV2504",
+                    "Segmentgruppe_FV2410|Segmentgruppe_FV2504",
+                ],
+                f"Segmentname_{self.formatversions.subsequent_formatversion}": [
+                    "Segment",
+                    "Segment",
+                    "Seg\nment",
+                    "Seg\nment",
+                ],
+                f"Segmentgruppe_{self.formatversions.subsequent_formatversion}": [
+                    "a",
+                    "b",
+                    "d",
+                    "d",
+                ],
+            }
+        )
+
+        output_df = align_columns(
+            previous_pruefid,
+            subsequent_pruefid,
+            previous_formatversion=self.formatversions.previous_formatversion,
+            subsequent_formatversion=self.formatversions.subsequent_formatversion,
+        )
+        assert_frame_equal(output_df, expected_output)
+
+    def test_remove_whitespace_tab(self) -> None:
+        """
+        this test case should not detect any since whitespace is removed during the comparison process
+        """
+        previous_pruefid = pd.DataFrame(
+            {
+                "Segmentname": ["Seg\tment", "Seg\tment", "Segment", "Segment"],
+                "Segmentgruppe": ["a", "b", "c", ""],
+            }
+        )
+        subsequent_pruefid = pd.DataFrame(
+            {
+                "Segmentname": ["Segment", "Segment", "Seg\tment", "Seg\tment"],
+                "Segmentgruppe": ["a", "b", "d", "d"],
+            }
+        )
+
+        expected_output: DataFrame = pd.DataFrame(
+            {
+                f"Segmentname_{self.formatversions.previous_formatversion}": [
+                    "Seg\tment",
+                    "Seg\tment",
+                    "Segment",
+                    "Segment",
+                ],
+                f"Segmentgruppe_{self.formatversions.previous_formatversion}": [
+                    "a",
+                    "b",
+                    "c",
+                    "",
+                ],
+                "Änderung": ["", "", "ÄNDERUNG", "ÄNDERUNG"],
+                "changed_entries": [
+                    "",
+                    "",
+                    "Segmentgruppe_FV2410|Segmentgruppe_FV2504",
+                    "Segmentgruppe_FV2410|Segmentgruppe_FV2504",
+                ],
+                f"Segmentname_{self.formatversions.subsequent_formatversion}": [
+                    "Segment",
+                    "Segment",
+                    "Seg\tment",
+                    "Seg\tment",
                 ],
                 f"Segmentgruppe_{self.formatversions.subsequent_formatversion}": [
                     "a",


### PR DESCRIPTION
before:
<img width="1899" alt="Screenshot 2024-11-20 at 10 36 00" src="https://github.com/user-attachments/assets/da5ab0d5-2629-4f99-8bd9-70d2327ddb60">

now its fixed; shoutouts to @DeltaDaniel 
<img width="1901" alt="Screenshot 2024-11-20 at 10 35 37" src="https://github.com/user-attachments/assets/cc4f4898-e2e7-4f5a-a2ba-eccc2448a402">